### PR TITLE
Allowed more flexibility with expressions

### DIFF
--- a/grammar.lark
+++ b/grammar.lark
@@ -7,9 +7,8 @@ label: WORD ":"
 exp: precedence_1_expression
 !precedence_1_expression: precedence_2_expression | precedence_2_expression ("+"|"-") precedence_2_expression
 !precedence_2_expression: precedence_3_expression | precedence_3_expression ("*"|"/") precedence_3_expression
-!precedence_3_expression: top_precedence_expression
-top_precedence_expression: top_prec_expr_not_id | identifier_or_array_access
-top_prec_expr_not_id: "(" exp ")"
+!precedence_3_expression: top_precedence_expression | identifier_or_array_access
+top_precedence_expression: "(" exp ")"
                          | call
                          | integer
 variable_declaration: "let" ("[" compile_time_exp "]")? identifier ":" size ("=" compile_time_exp)?
@@ -17,7 +16,7 @@ if_statement: "if" exp code_block ("else" code_block)?
 loop: "while" exp code_block
 code_block: "{" statement+ "}"
 call: identifier "(" exp ("," exp)*  ")"
-identifier_or_array_access: top_prec_expr_not_id ("[" exp "]")*
+identifier_or_array_access: top_precedence_expression ("[" exp "]")*
 label_name: WORD
 identifier: WORD
 compile_time_exp: integer

--- a/grammar.lark
+++ b/grammar.lark
@@ -8,21 +8,20 @@ exp: precedence_1_expression
 !precedence_1_expression: precedence_2_expression | precedence_2_expression ("+"|"-") precedence_2_expression
 !precedence_2_expression: precedence_3_expression | precedence_3_expression ("*"|"/") precedence_3_expression
 !precedence_3_expression: top_precedence_expression
-top_precedence_expression: "(" exp ")"
-                         | identifier_or_array_access
+top_precedence_expression: top_prec_expr_not_id | identifier_or_array_access
+top_prec_expr_not_id: "(" exp ")"
                          | call
                          | integer
-variable_declaration: "let" ("[" indices "]")? identifier ":" size ("=" compile_time_exp)?
+variable_declaration: "let" ("[" compile_time_exp "]")? identifier ":" size ("=" compile_time_exp)?
 if_statement: "if" exp code_block ("else" code_block)?
 loop: "while" exp code_block
 code_block: "{" statement+ "}"
 call: identifier "(" exp ("," exp)*  ")"
-identifier_or_array_access: identifier ("[" exp "]")*
+identifier_or_array_access: top_prec_expr_not_id ("[" exp "]")*
 label_name: WORD
 identifier: WORD
 compile_time_exp: integer
 size: positive_integer
-indices: positive_integer
 WORD: ("a".."z"|"A".."Z") ("a".."z"|"A".."Z"|"0".."9"|"$")*
 integer: positive_integer | negative_integer
 negative_integer: "-" positive_integer


### PR DESCRIPTION
e.x.: `f()[1][2][3]`